### PR TITLE
Support int32_vector type.

### DIFF
--- a/kaldi_native_io/csrc/kaldi-holder-inl.h
+++ b/kaldi_native_io/csrc/kaldi-holder-inl.h
@@ -116,6 +116,127 @@ class BasicHolder {
   T t_;
 };
 
+/// A Holder for a vector of basic types, e.g.
+/// std::vector<int32_t>, std::vector<float>, and so on.
+/// Note: a basic type is defined as a type for which ReadBasicType
+/// and WriteBasicType are implemented, i.e. integer and floating
+/// types, and bool.
+template <class BasicType>
+class BasicVectorHolder {
+ public:
+  typedef std::vector<BasicType> T;
+
+  BasicVectorHolder() {}
+
+  static bool Write(std::ostream &os, bool binary, const T &t) {
+    InitKaldiOutputStream(os, binary);  // Puts binary header if binary mode.
+    try {
+      if (binary) {  // need to write the size, in binary mode.
+        KALDIIO_ASSERT(static_cast<size_t>(static_cast<int32_t>(t.size())) ==
+                       t.size());
+        // Or this Write routine cannot handle such a large vector.
+        // use int32_t because it's fixed size regardless of compilation.
+        // change to int64 (plus in Read function) if this becomes a problem.
+        WriteBasicType(os, binary, static_cast<int32_t>(t.size()));
+        for (typename std::vector<BasicType>::const_iterator iter = t.begin();
+             iter != t.end(); ++iter)
+          WriteBasicType(os, binary, *iter);
+
+      } else {
+        for (typename std::vector<BasicType>::const_iterator iter = t.begin();
+             iter != t.end(); ++iter)
+          WriteBasicType(os, binary, *iter);
+        os << '\n';  // Makes output format more readable and
+        // easier to manipulate.  In text mode, this function writes something
+        // like "1 2 3\n".
+      }
+      return os.good();
+    } catch (const std::exception &e) {
+      KALDIIO_WARN << "Exception caught writing Table object (BasicVector). "
+                   << e.what();
+      return false;  // Write failure.
+    }
+  }
+
+  void Clear() { t_.clear(); }
+
+  // Reads into the holder.
+  bool Read(std::istream &is) {
+    t_.clear();
+    bool is_binary;
+    if (!InitKaldiInputStream(is, &is_binary)) {
+      KALDIIO_WARN
+          << "Reading Table object [integer type], failed reading binary"
+             " header\n";
+      return false;
+    }
+    if (!is_binary) {
+      // In text mode, we terminate with newline.
+      std::string line;
+      getline(is, line);  // this will discard the \n, if present.
+      if (is.fail()) {
+        KALDIIO_WARN << "BasicVectorHolder::Read, error reading line "
+                     << (is.eof() ? "[eof]" : "");
+        return false;  // probably eof.  fail in any case.
+      }
+      std::istringstream line_is(line);
+      try {
+        while (1) {
+          line_is >> std::ws;  // eat up whitespace.
+          if (line_is.eof()) break;
+          BasicType bt;
+          ReadBasicType(line_is, false, &bt);
+          t_.push_back(bt);
+        }
+        return true;
+      } catch (const std::exception &e) {
+        KALDIIO_WARN << "BasicVectorHolder::Read, could not interpret line: "
+                     << "'" << line << "'"
+                     << "\n"
+                     << e.what();
+        return false;
+      }
+    } else {  // binary mode.
+      size_t filepos = is.tellg();
+      try {
+        int32_t size;
+        ReadBasicType(is, true, &size);
+        t_.resize(size);
+        for (typename std::vector<BasicType>::iterator iter = t_.begin();
+             iter != t_.end(); ++iter) {
+          ReadBasicType(is, true, &(*iter));
+        }
+        return true;
+      } catch (...) {
+        KALDIIO_WARN << "BasicVectorHolder::Read, read error or unexpected data"
+                        " at archive entry beginning at file position "
+                     << filepos;
+        return false;
+      }
+    }
+  }
+
+  // Objects read/written with the Kaldi I/O functions always have the stream
+  // open in binary mode for reading.
+  static bool IsReadInBinary() { return true; }
+
+  T &Value() { return t_; }
+
+  void Swap(BasicVectorHolder<BasicType> *other) { t_.swap(other->t_); }
+
+  bool ExtractRange(const BasicVectorHolder<BasicType> &other,
+                    const std::string &range) {
+    KALDIIO_ERR << "ExtractRange is not defined for this type of holder.";
+    return false;
+  }
+
+  ~BasicVectorHolder() {}
+
+ private:
+  KALDIIO_DISALLOW_COPY_AND_ASSIGN(BasicVectorHolder);
+  T t_;
+};
+
 // We define a Token as a nonempty, printable, whitespace-free std::string.
 // The binary and text formats here are the same (newline-terminated)
 // and as such we don't bother with the binary-mode headers.

--- a/kaldi_native_io/csrc/kaldi-holder.h
+++ b/kaldi_native_io/csrc/kaldi-holder.h
@@ -21,6 +21,14 @@ namespace kaldiio {
 template <class BasicType>
 class BasicHolder;
 
+/// A Holder for a vector of basic types, e.g.
+/// std::vector<int32>, std::vector<float>, and so on.
+/// Note: a basic type is defined as a type for which ReadBasicType
+/// and WriteBasicType are implemented, i.e. integer and floating
+/// types, and bool.
+template <class BasicType>
+class BasicVectorHolder;
+
 /// We define a Token (not a typedef, just a word) as a nonempty, printable,
 /// whitespace-free std::string.  The binary and text formats here are the same
 /// (newline-terminated) and as such we don't bother with the binary-mode

--- a/kaldi_native_io/python/csrc/kaldi-table.cc
+++ b/kaldi_native_io/python/csrc/kaldi-table.cc
@@ -61,6 +61,12 @@ void PybindKaldiTable(py::module &m) {
                                                     "_SequentialInt32Reader");
   PybindRandomAccessTableReader<BasicHolder<int32_t>>(
       m, "_RandomAccessInt32Reader");
+
+  PybindTableWriter<BasicVectorHolder<int32_t>>(m, "_Int32VectorWriter");
+  PybindSequentialTableReader<BasicVectorHolder<int32_t>>(
+      m, "_SequentialInt32VectorReader");
+  PybindRandomAccessTableReader<BasicVectorHolder<int32_t>>(
+      m, "_RandomAccessInt32VectorReader");
 }
 
 }  // namespace kaldiio

--- a/kaldi_native_io/python/csrc/kaldiio.h
+++ b/kaldi_native_io/python/csrc/kaldiio.h
@@ -6,6 +6,7 @@
 #define KALDI_NATIVE_IO_PYTHON_CSRC_KALDIIO_H_
 
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 namespace py = pybind11;
 

--- a/kaldi_native_io/python/kaldi_native_io/__init__.py
+++ b/kaldi_native_io/python/kaldi_native_io/__init__.py
@@ -1,5 +1,8 @@
 from .table_types import (
+    Int32VectorWriter,
     Int32Writer,
     RandomAccessInt32Reader,
+    RandomAccessInt32VectorReader,
     SequentialInt32Reader,
+    SequentialInt32VectorReader,
 )

--- a/kaldi_native_io/python/kaldi_native_io/table_types.py
+++ b/kaldi_native_io/python/kaldi_native_io/table_types.py
@@ -5,9 +5,12 @@
 from typing import Any, Tuple
 
 from _kaldi_native_io import (
+    _Int32VectorWriter,
     _Int32Writer,
     _RandomAccessInt32Reader,
+    _RandomAccessInt32VectorReader,
     _SequentialInt32Reader,
+    _SequentialInt32VectorReader,
 )
 
 
@@ -184,3 +187,18 @@ class SequentialInt32Reader(_SequentialTableReader):
 class RandomAccessInt32Reader(_RandomAccessTableReader):
     def open(self, rspecifier: str) -> None:
         self._impl = _RandomAccessInt32Reader(rspecifier)
+
+
+class Int32VectorWriter(_TableWriter):
+    def open(self, wspecifier: str) -> None:
+        self._impl = _Int32VectorWriter(wspecifier)
+
+
+class SequentialInt32VectorReader(_SequentialTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _SequentialInt32VectorReader(rspecifier)
+
+
+class RandomAccessInt32VectorReader(_RandomAccessTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _RandomAccessInt32VectorReader(rspecifier)

--- a/kaldi_native_io/python/tests/CMakeLists.txt
+++ b/kaldi_native_io/python/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction()
 
 # please sort the files in alphabetic order
 set(py_test_files
+  test_int32_vector_writer_reader.py
   test_int32_writer_reader.py
 )
 

--- a/kaldi_native_io/python/tests/test_int32_vector_writer_reader.py
+++ b/kaldi_native_io/python/tests/test_int32_vector_writer_reader.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+# Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+
+import os
+
+import kaldi_native_io
+
+wspecifier = "ark,scp,t:int32_vector.ark,int32_vector.scp"
+rspecifier = "scp:int32_vector.scp"
+
+
+def test_int32_vector_writer():
+    with kaldi_native_io.Int32VectorWriter(wspecifier) as ko:
+        ko.write("a", [10, 20])
+        ko["b"] = [100, 200, 300]
+
+
+def test_sequential_int32_vector_reader():
+    with kaldi_native_io.SequentialInt32VectorReader(rspecifier) as ki:
+        for key, value in ki:
+            if key == "a":
+                assert value == [10, 20]
+            elif key == "b":
+                assert value == [100, 200, 300]
+            else:
+                raise ValueError(f"Unknown key {key} with value {value}")
+
+
+def test_random_access_int32_vector_reader():
+    with kaldi_native_io.RandomAccessInt32VectorReader(rspecifier) as ki:
+        assert "b" in ki
+        assert "a" in ki
+        assert ki["a"] == [10, 20]
+        assert ki["b"] == [100, 200, 300]
+
+
+def main():
+    test_int32_vector_writer()
+    test_sequential_int32_vector_reader()
+    test_random_access_int32_vector_reader()
+
+    os.remove("int32_vector.scp")
+    os.remove("int32_vector.ark")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
See
https://github.com/csukuangfj/kaldi_native_io/blob/87ee5c00d003f7e09fd388f3dc878771df12b46e/kaldi_native_io/python/tests/test_int32_vector_writer_reader.py#L7-L35
for usages.