### PR TITLE
Support int32_vector_vector type.

### DIFF
--- a/kaldi_native_io/csrc/kaldi-holder-inl.h
+++ b/kaldi_native_io/csrc/kaldi-holder-inl.h
@@ -237,6 +237,156 @@ class BasicVectorHolder {
   T t_;
 };
 
+/// BasicVectorVectorHolder is a Holder for a vector of vector of
+/// a basic type, e.g. std::vector<std::vector<int32_t> >.
+/// Note: a basic type is defined as a type for which ReadBasicType
+/// and WriteBasicType are implemented, i.e. integer and floating
+/// types, and bool.
+template <class BasicType>
+class BasicVectorVectorHolder {
+ public:
+  typedef std::vector<std::vector<BasicType>> T;
+
+  BasicVectorVectorHolder() {}
+
+  static bool Write(std::ostream &os, bool binary, const T &t) {
+    InitKaldiOutputStream(os, binary);  // Puts binary header if binary mode.
+    try {
+      if (binary) {  // need to write the size, in binary mode.
+        KALDIIO_ASSERT(static_cast<size_t>(static_cast<int32_t>(t.size())) ==
+                       t.size());
+        // Or this Write routine cannot handle such a large vector.
+        // use int32_t because it's fixed size regardless of compilation.
+        // change to int64 (plus in Read function) if this becomes a problem.
+        WriteBasicType(os, binary, static_cast<int32_t>(t.size()));
+        for (typename std::vector<std::vector<BasicType>>::const_iterator iter =
+                 t.begin();
+             iter != t.end(); ++iter) {
+          KALDIIO_ASSERT(static_cast<size_t>(static_cast<int32_t>(
+                             iter->size())) == iter->size());
+          WriteBasicType(os, binary, static_cast<int32_t>(iter->size()));
+          for (typename std::vector<BasicType>::const_iterator iter2 =
+                   iter->begin();
+               iter2 != iter->end(); ++iter2) {
+            WriteBasicType(os, binary, *iter2);
+          }
+        }
+      } else {  // text mode...
+        // In text mode, we write out something like (for integers):
+        // "1 2 3 ; 4 5 ; 6 ; ; 7 8 9 ;\n"
+        // where the semicolon is a terminator, not a separator
+        // (a separator would cause ambiguity between an
+        // empty list, and a list containing a single empty list).
+        for (typename std::vector<std::vector<BasicType>>::const_iterator iter =
+                 t.begin();
+             iter != t.end(); ++iter) {
+          for (typename std::vector<BasicType>::const_iterator iter2 =
+                   iter->begin();
+               iter2 != iter->end(); ++iter2)
+            WriteBasicType(os, binary, *iter2);
+          os << "; ";
+        }
+        os << '\n';
+      }
+      return os.good();
+    } catch (const std::exception &e) {
+      KALDIIO_WARN << "Exception caught writing Table object. " << e.what();
+      return false;  // Write failure.
+    }
+  }
+
+  void Clear() { t_.clear(); }
+
+  // Reads into the holder.
+  bool Read(std::istream &is) {
+    t_.clear();
+    bool is_binary;
+    if (!InitKaldiInputStream(is, &is_binary)) {
+      KALDIIO_WARN << "Failed reading binary header\n";
+      return false;
+    }
+    if (!is_binary) {
+      // In text mode, we terminate with newline.
+      try {                        // catching errors from ReadBasicType..
+        std::vector<BasicType> v;  // temporary vector
+        while (1) {
+          int i = is.peek();
+          if (i == -1) {
+            KALDIIO_WARN << "Unexpected EOF";
+            return false;
+          } else if (static_cast<char>(i) == '\n') {
+            if (!v.empty()) {
+              KALDIIO_WARN << "No semicolon before newline (wrong format)";
+              return false;
+            } else {
+              is.get();
+              return true;
+            }
+          } else if (std::isspace(i)) {
+            is.get();
+          } else if (static_cast<char>(i) == ';') {
+            t_.push_back(v);
+            v.clear();
+            is.get();
+          } else {  // some object we want to read...
+            BasicType b;
+            ReadBasicType(is, false, &b);  // throws on error.
+            v.push_back(b);
+          }
+        }
+      } catch (const std::exception &e) {
+        KALDIIO_WARN << "BasicVectorVectorHolder::Read, read error. "
+                     << e.what();
+        return false;
+      }
+    } else {  // binary mode.
+      size_t filepos = is.tellg();
+      try {
+        int32_t size;
+        ReadBasicType(is, true, &size);
+        t_.resize(size);
+        for (typename std::vector<std::vector<BasicType>>::iterator iter =
+                 t_.begin();
+             iter != t_.end(); ++iter) {
+          int32_t size2;
+          ReadBasicType(is, true, &size2);
+          iter->resize(size2);
+          for (typename std::vector<BasicType>::iterator iter2 = iter->begin();
+               iter2 != iter->end(); ++iter2)
+            ReadBasicType(is, true, &(*iter2));
+        }
+        return true;
+      } catch (...) {
+        KALDIIO_WARN
+            << "Read error or unexpected data at archive entry beginning"
+               " at file position "
+            << filepos;
+        return false;
+      }
+    }
+  }
+
+  // Objects read/written with the Kaldi I/O functions always have the stream
+  // open in binary mode for reading.
+  static bool IsReadInBinary() { return true; }
+
+  T &Value() { return t_; }
+
+  void Swap(BasicVectorVectorHolder<BasicType> *other) { t_.swap(other->t_); }
+
+  bool ExtractRange(BasicVectorVectorHolder<BasicType> &other,
+                    const std::string &range) {
+    KALDIIO_ERR << "ExtractRange is not defined for this type of holder.";
+    return false;
+  }
+
+  ~BasicVectorVectorHolder() {}
+
+ private:
+  KALDIIO_DISALLOW_COPY_AND_ASSIGN(BasicVectorVectorHolder);
+  T t_;
+};
+
 // We define a Token as a nonempty, printable, whitespace-free std::string.
 // The binary and text formats here are the same (newline-terminated)
 // and as such we don't bother with the binary-mode headers.

--- a/kaldi_native_io/csrc/kaldi-holder.h
+++ b/kaldi_native_io/csrc/kaldi-holder.h
@@ -29,6 +29,14 @@ class BasicHolder;
 template <class BasicType>
 class BasicVectorHolder;
 
+// A holder for vectors of vectors of basic types, e.g.
+// std::vector<std::vector<int32> >, and so on.
+// Note: a basic type is defined as a type for which ReadBasicType
+// and WriteBasicType are implemented, i.e. integer and floating
+// types, and bool.
+template <class BasicType>
+class BasicVectorVectorHolder;
+
 /// We define a Token (not a typedef, just a word) as a nonempty, printable,
 /// whitespace-free std::string.  The binary and text formats here are the same
 /// (newline-terminated) and as such we don't bother with the binary-mode

--- a/kaldi_native_io/python/csrc/kaldi-table.cc
+++ b/kaldi_native_io/python/csrc/kaldi-table.cc
@@ -67,6 +67,13 @@ void PybindKaldiTable(py::module &m) {
       m, "_SequentialInt32VectorReader");
   PybindRandomAccessTableReader<BasicVectorHolder<int32_t>>(
       m, "_RandomAccessInt32VectorReader");
+
+  PybindTableWriter<BasicVectorVectorHolder<int32_t>>(
+      m, "_Int32VectorVectorWriter");
+  PybindSequentialTableReader<BasicVectorVectorHolder<int32_t>>(
+      m, "_SequentialInt32VectorVectorReader");
+  PybindRandomAccessTableReader<BasicVectorVectorHolder<int32_t>>(
+      m, "_RandomAccessInt32VectorVectorReader");
 }
 
 }  // namespace kaldiio

--- a/kaldi_native_io/python/kaldi_native_io/__init__.py
+++ b/kaldi_native_io/python/kaldi_native_io/__init__.py
@@ -1,8 +1,11 @@
 from .table_types import (
+    Int32VectorVectorWriter,
     Int32VectorWriter,
     Int32Writer,
     RandomAccessInt32Reader,
     RandomAccessInt32VectorReader,
+    RandomAccessInt32VectorVectorReader,
     SequentialInt32Reader,
     SequentialInt32VectorReader,
+    SequentialInt32VectorVectorReader,
 )

--- a/kaldi_native_io/python/kaldi_native_io/table_types.py
+++ b/kaldi_native_io/python/kaldi_native_io/table_types.py
@@ -5,12 +5,15 @@
 from typing import Any, Tuple
 
 from _kaldi_native_io import (
+    _Int32VectorVectorWriter,
     _Int32VectorWriter,
     _Int32Writer,
     _RandomAccessInt32Reader,
     _RandomAccessInt32VectorReader,
+    _RandomAccessInt32VectorVectorReader,
     _SequentialInt32Reader,
     _SequentialInt32VectorReader,
+    _SequentialInt32VectorVectorReader,
 )
 
 
@@ -202,3 +205,18 @@ class SequentialInt32VectorReader(_SequentialTableReader):
 class RandomAccessInt32VectorReader(_RandomAccessTableReader):
     def open(self, rspecifier: str) -> None:
         self._impl = _RandomAccessInt32VectorReader(rspecifier)
+
+
+class Int32VectorVectorWriter(_TableWriter):
+    def open(self, wspecifier: str) -> None:
+        self._impl = _Int32VectorVectorWriter(wspecifier)
+
+
+class SequentialInt32VectorVectorReader(_SequentialTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _SequentialInt32VectorVectorReader(rspecifier)
+
+
+class RandomAccessInt32VectorVectorReader(_RandomAccessTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _RandomAccessInt32VectorVectorReader(rspecifier)

--- a/kaldi_native_io/python/tests/CMakeLists.txt
+++ b/kaldi_native_io/python/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction()
 
 # please sort the files in alphabetic order
 set(py_test_files
+  test_int32_vector_vector_writer_reader.py
   test_int32_vector_writer_reader.py
   test_int32_writer_reader.py
 )

--- a/kaldi_native_io/python/tests/test_int32_vector_vector_writer_reader.py
+++ b/kaldi_native_io/python/tests/test_int32_vector_vector_writer_reader.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+
+import os
+
+import kaldi_native_io
+
+base = "int32_vector_vector"
+wspecifier = f"ark,scp,t:{base}.ark,{base}.scp"
+rspecifier = f"scp:{base}.scp"
+
+
+def test_int32_vector_vector_writer():
+    with kaldi_native_io.Int32VectorVectorWriter(wspecifier) as ko:
+        ko.write("a", [[10, 20], [-2]])
+        ko["b"] = [[100, 200, 300], [3, 5]]
+
+
+def test_sequential_int32_vector_vector_reader():
+    with kaldi_native_io.SequentialInt32VectorVectorReader(rspecifier) as ki:
+        for key, value in ki:
+            if key == "a":
+                assert value == [[10, 20], [-2]]
+            elif key == "b":
+                assert value == [[100, 200, 300], [3, 5]]
+            else:
+                raise ValueError(f"Unknown key {key} with value {value}")
+
+
+def test_random_access_int32_vector_vector_reader():
+    with kaldi_native_io.RandomAccessInt32VectorVectorReader(rspecifier) as ki:
+        assert "b" in ki
+        assert "a" in ki
+        assert ki["a"] == [[10, 20], [-2]]
+        assert ki["b"] == [[100, 200, 300], [3, 5]]
+
+
+def main():
+    test_int32_vector_vector_writer()
+    test_sequential_int32_vector_vector_reader()
+    test_random_access_int32_vector_vector_reader()
+
+    os.remove(f"{base}.scp")
+    os.remove(f"{base}.ark")
+
+
+if __name__ == "__main__":
+    main()

--- a/kaldi_native_io/python/tests/test_int32_vector_writer_reader.py
+++ b/kaldi_native_io/python/tests/test_int32_vector_writer_reader.py
@@ -6,8 +6,9 @@ import os
 
 import kaldi_native_io
 
-wspecifier = "ark,scp,t:int32_vector.ark,int32_vector.scp"
-rspecifier = "scp:int32_vector.scp"
+base = "int32_vector"
+wspecifier = f"ark,scp,t:{base}.ark,{base}.scp"
+rspecifier = f"scp:{base}.scp"
 
 
 def test_int32_vector_writer():
@@ -40,8 +41,8 @@ def main():
     test_sequential_int32_vector_reader()
     test_random_access_int32_vector_reader()
 
-    os.remove("int32_vector.scp")
-    os.remove("int32_vector.ark")
+    os.remove(f"{base}.scp")
+    os.remove(f"{base}.ark")
 
 
 if __name__ == "__main__":

--- a/kaldi_native_io/python/tests/test_int32_writer_reader.py
+++ b/kaldi_native_io/python/tests/test_int32_writer_reader.py
@@ -6,8 +6,9 @@ import os
 
 import kaldi_native_io
 
-wspecifier = "ark,scp,t:int32.ark,int32.scp"
-rspecifier = "scp:int32.scp"
+base = "int32"
+wspecifier = f"ark,scp,t:{base}.ark,{base}.scp"
+rspecifier = f"scp:{base}.scp"
 
 
 def test_int32_writer():
@@ -40,8 +41,8 @@ def main():
     test_sequential_int32_reader()
     test_random_access_int32_reader()
 
-    os.remove("int32.scp")
-    os.remove("int32.ark")
+    os.remove(f"{base}.scp")
+    os.remove(f"{base}.ark")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
See
https://github.com/csukuangfj/kaldi_native_io/blob/2fc5c14560000f5ca27aa039a79eb5f2255a08ef/kaldi_native_io/python/tests/test_int32_vector_vector_writer_reader.py#L7-L36
for usages.