### PR TITLE
Add int32_pair_vector type.

### DIFF
--- a/kaldi_native_io/csrc/kaldi-holder.h
+++ b/kaldi_native_io/csrc/kaldi-holder.h
@@ -37,6 +37,15 @@ class BasicVectorHolder;
 template <class BasicType>
 class BasicVectorVectorHolder;
 
+// A holder for vectors of pairs of basic types, e.g.
+// std::vector<std::pair<int32, int32> >, and so on.
+// Note: a basic type is defined as a type for which ReadBasicType
+// and WriteBasicType are implemented, i.e. integer and floating
+// types, and bool.  Text format is (e.g. for integers),
+// "1 12 ; 43 61 ; 17 8 \n"
+template <class BasicType>
+class BasicPairVectorHolder;
+
 /// We define a Token (not a typedef, just a word) as a nonempty, printable,
 /// whitespace-free std::string.  The binary and text formats here are the same
 /// (newline-terminated) and as such we don't bother with the binary-mode

--- a/kaldi_native_io/python/csrc/kaldi-table.cc
+++ b/kaldi_native_io/python/csrc/kaldi-table.cc
@@ -74,6 +74,13 @@ void PybindKaldiTable(py::module &m) {
       m, "_SequentialInt32VectorVectorReader");
   PybindRandomAccessTableReader<BasicVectorVectorHolder<int32_t>>(
       m, "_RandomAccessInt32VectorVectorReader");
+
+  PybindTableWriter<BasicPairVectorHolder<int32_t>>(m,
+                                                    "_Int32PairVectorWriter");
+  PybindSequentialTableReader<BasicPairVectorHolder<int32_t>>(
+      m, "_SequentialInt32PairVectorReader");
+  PybindRandomAccessTableReader<BasicPairVectorHolder<int32_t>>(
+      m, "_RandomAccessInt32PairVectorReader");
 }
 
 }  // namespace kaldiio

--- a/kaldi_native_io/python/kaldi_native_io/__init__.py
+++ b/kaldi_native_io/python/kaldi_native_io/__init__.py
@@ -1,10 +1,13 @@
 from .table_types import (
+    Int32PairVectorWriter,
     Int32VectorVectorWriter,
     Int32VectorWriter,
     Int32Writer,
+    RandomAccessInt32PairVectorReader,
     RandomAccessInt32Reader,
     RandomAccessInt32VectorReader,
     RandomAccessInt32VectorVectorReader,
+    SequentialInt32PairVectorReader,
     SequentialInt32Reader,
     SequentialInt32VectorReader,
     SequentialInt32VectorVectorReader,

--- a/kaldi_native_io/python/kaldi_native_io/table_types.py
+++ b/kaldi_native_io/python/kaldi_native_io/table_types.py
@@ -5,12 +5,15 @@
 from typing import Any, Tuple
 
 from _kaldi_native_io import (
+    _Int32PairVectorWriter,
     _Int32VectorVectorWriter,
     _Int32VectorWriter,
     _Int32Writer,
+    _RandomAccessInt32PairVectorReader,
     _RandomAccessInt32Reader,
     _RandomAccessInt32VectorReader,
     _RandomAccessInt32VectorVectorReader,
+    _SequentialInt32PairVectorReader,
     _SequentialInt32Reader,
     _SequentialInt32VectorReader,
     _SequentialInt32VectorVectorReader,
@@ -220,3 +223,18 @@ class SequentialInt32VectorVectorReader(_SequentialTableReader):
 class RandomAccessInt32VectorVectorReader(_RandomAccessTableReader):
     def open(self, rspecifier: str) -> None:
         self._impl = _RandomAccessInt32VectorVectorReader(rspecifier)
+
+
+class Int32PairVectorWriter(_TableWriter):
+    def open(self, wspecifier: str) -> None:
+        self._impl = _Int32PairVectorWriter(wspecifier)
+
+
+class SequentialInt32PairVectorReader(_SequentialTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _SequentialInt32PairVectorReader(rspecifier)
+
+
+class RandomAccessInt32PairVectorReader(_RandomAccessTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _RandomAccessInt32PairVectorReader(rspecifier)

--- a/kaldi_native_io/python/tests/test_int32_pair_vector_writer_reader.py
+++ b/kaldi_native_io/python/tests/test_int32_pair_vector_writer_reader.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+
+import os
+
+import kaldi_native_io
+
+base = "int32_pair_vector"
+wspecifier = f"ark,scp,t:{base}.ark,{base}.scp"
+rspecifier = f"scp:{base}.scp"
+
+
+def test_int32_pair_vector_writer():
+    with kaldi_native_io.Int32PairVectorWriter(wspecifier) as ko:
+        ko.write("a", [(10, 20), (-1, -2)])
+        ko["b"] = [(3, 4), (6, 8), (9, 0)]
+
+
+def test_sequential_int32_pair_vector_reader():
+    with kaldi_native_io.SequentialInt32PairVectorReader(rspecifier) as ki:
+        for key, value in ki:
+            if key == "a":
+                assert value == [(10, 20), (-1, -2)]
+            elif key == "b":
+                assert value == [(3, 4), (6, 8), (9, 0)]
+            else:
+                raise ValueError(f"Unknown key {key} with value {value}")
+
+
+def test_random_access_int32_pair_vector_reader():
+    with kaldi_native_io.RandomAccessInt32PairVectorReader(rspecifier) as ki:
+        assert "b" in ki
+        assert "a" in ki
+        assert ki["a"] == [(10, 20), (-1, -2)]
+        assert ki["b"] == [(3, 4), (6, 8), (9, 0)]
+
+
+def main():
+    test_int32_pair_vector_writer()
+    test_sequential_int32_pair_vector_reader()
+    test_random_access_int32_pair_vector_reader()
+
+    os.remove(f"{base}.scp")
+    os.remove(f"{base}.ark")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
See
https://github.com/csukuangfj/kaldi_native_io/blob/d2737dae7a5e08893cbb9189342dd3241d8cb323/kaldi_native_io/python/tests/test_int32_pair_vector_writer_reader.py#L7-L36
for usages.