### PR TITLE
Fix reading wave info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ is provided to read ark/scp files from Kaldi in Python.
 |`kaldi::Posterior`|`PosteriorWriter`|`SequentialPosteriorReader`|`RandomAccessPosteriorReader`|
 |`kaldi::GausPost`|`GaussPostWriter`|`SequentialGaussPostReader`|`RandomAccessGaussPostReader`|
 |`kaldi::WaveInfo`|-|`SequentialWaveInfoReader`|`RandomAccessWaveInfoReader`|
+|`kaldi::WaveData`|-|`SequentialWaveReader`|`RandomAccessWaveReader`|
 
 # Installation
 

--- a/kaldi_native_io/csrc/kaldi-io.cc
+++ b/kaldi_native_io/csrc/kaldi-io.cc
@@ -20,6 +20,40 @@
 
 namespace kaldiio {
 
+std::string InputTypeToString(InputType t) {
+  switch (t) {
+    case kNoInput:
+      return "kNoInput";
+    case kFileInput:
+      return "kFileInput";
+    case kStandardInput:
+      return "kStandardInput";
+    case kOffsetFileInput:
+      return "kOffsetFileInput";
+    case kPipeInput:
+      return "kPipeInput";
+    default:
+      KALDIIO_ERR << "Unknown type";
+      return "Unknown";
+  }
+}
+
+std::string OutputTypeToString(OutputType t) {
+  switch (t) {
+    case kNoOutput:
+      return "kNoOutput";
+    case kFileOutput:
+      return "kFileOutput";
+    case kStandardOutput:
+      return "kStandardOutput";
+    case kPipeOutput:
+      return "kPipeOutput";
+    default:
+      KALDIIO_ERR << "Unknown type";
+      return "Unknown";
+  }
+}
+
 std::string PrintableRxfilename(const std::string &rxfilename) {
   if (rxfilename == "" || rxfilename == "-") {
     return "standard input";

--- a/kaldi_native_io/csrc/kaldi-io.h
+++ b/kaldi_native_io/csrc/kaldi-io.h
@@ -63,6 +63,8 @@ class InputImplBase;   // Forward decl; defined in a .cc file
 // }
 enum OutputType { kNoOutput, kFileOutput, kStandardOutput, kPipeOutput };
 
+std::string OutputTypeToString(OutputType t);
+
 /// ClassifyWxfilename interprets filenames as follows:
 ///  - kNoOutput: invalid filenames (leading or trailing space, things that look
 ///     like wspecifiers and rspecifiers or like pipes to read from with leading
@@ -89,6 +91,8 @@ enum InputType {
 ///  - kPipeInput: e.g. "gunzip -c /tmp/abc.gz |"
 ///  - kOffsetFileInput: offsets into files, e.g.  /some/filename:12970
 InputType ClassifyRxfilename(const std::string &rxfilename);
+
+std::string InputTypeToString(InputType t);
 
 class Output {
  public:

--- a/kaldi_native_io/python/kaldi_native_io/__init__.py
+++ b/kaldi_native_io/python/kaldi_native_io/__init__.py
@@ -1,8 +1,10 @@
 from _kaldi_native_io import (
     CompressionMethod,
     HtkHeader,
+    WaveData,
     WaveInfo,
     read_wave_info,
+    read_wave,
 )
 
 from .table_types import (
@@ -40,6 +42,7 @@ from .table_types import (
     RandomAccessTokenReader,
     RandomAccessTokenVectorReader,
     RandomAccessWaveInfoReader,
+    RandomAccessWaveReader,
     SequentialBoolReader,
     SequentialDoubleMatrixReader,
     SequentialDoubleReader,
@@ -58,6 +61,7 @@ from .table_types import (
     SequentialTokenReader,
     SequentialTokenVectorReader,
     SequentialWaveInfoReader,
+    SequentialWaveReader,
     TokenVectorWriter,
     TokenWriter,
 )

--- a/kaldi_native_io/python/kaldi_native_io/table_types.py
+++ b/kaldi_native_io/python/kaldi_native_io/table_types.py
@@ -47,6 +47,7 @@ from _kaldi_native_io import (
     _RandomAccessTokenReader,
     _RandomAccessTokenVectorReader,
     _RandomAccessWaveInfoReader,
+    _RandomAccessWaveReader,
     _SequentialBoolReader,
     _SequentialDoubleMatrixReader,
     _SequentialDoubleReader,
@@ -65,6 +66,7 @@ from _kaldi_native_io import (
     _SequentialTokenReader,
     _SequentialTokenVectorReader,
     _SequentialWaveInfoReader,
+    _SequentialWaveReader,
     _TokenVectorWriter,
     _TokenWriter,
 )
@@ -719,10 +721,30 @@ class RandomAccessGaussPostReader(_RandomAccessTableReader):
 
 
 class SequentialWaveInfoReader(_SequentialTableReader):
+    """Caution: It does not support pipe input yet since it
+    closes the pipe as soon as it reads the header, which
+    causes pipe write error as the producer is still generating data.
+    """
+
     def open(self, rspecifier: str) -> None:
         self._impl = _SequentialWaveInfoReader(rspecifier)
 
 
 class RandomAccessWaveInfoReader(_RandomAccessTableReader):
+    """Caution: It does not support pipe input yet since it
+    closes the pipe as soon as it reads the header, which
+    causes pipe write error as the producer is still generating data.
+    """
+
     def open(self, rspecifier: str) -> None:
         self._impl = _RandomAccessWaveInfoReader(rspecifier)
+
+
+class SequentialWaveReader(_SequentialTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _SequentialWaveReader(rspecifier)
+
+
+class RandomAccessWaveReader(_RandomAccessTableReader):
+    def open(self, rspecifier: str) -> None:
+        self._impl = _RandomAccessWaveReader(rspecifier)

--- a/kaldi_native_io/python/tests/CMakeLists.txt
+++ b/kaldi_native_io/python/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ set(py_test_files
   test_token_vector_writer_reader.py
   test_token_writer_reader.py
   test_wave_info_reader.py
+  test_wave_reader.py
 )
 
 foreach(source IN LISTS py_test_files)

--- a/kaldi_native_io/python/tests/test_wave_reader.py
+++ b/kaldi_native_io/python/tests/test_wave_reader.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright      2022  Xiaomi Corporation (authors: Fangjun Kuang)
+from pathlib import Path
+
+import kaldi_native_io
+
+
+base = "/ceph-fj/fangjun/open-source-2/kaldi_native_io/build/a.scp"
+rspecifier = f"scp:{base}"
+
+# a.scp contains something like the following:
+"""
+a /path/to/foo.wav
+b /path/to/bar.wav
+"""
+
+
+def test_sequential_wave_reader():
+    with kaldi_native_io.SequentialWaveReader(rspecifier) as ki:
+        for key, value in ki:
+            print(
+                key,
+                f"sample_freq: {value.sample_freq}, "
+                f"duration: {value.duration} (seconds)",
+                f"data shape: {value.data.numpy().shape}",
+            )
+
+
+def test_random_access_wave_reader():
+    with kaldi_native_io.RandomAccessWaveReader(rspecifier) as ki:
+        assert "a" in ki
+        assert "b" in ki
+        # You can access the following fields of ki['a'] and ki['b']
+        # - sample_freq
+        # - duration (in seconds)
+        # - data.numpy() (a 2-D array of shape (num_channels, num_samples)
+        # Note: the data is not normalized, i.e., it is in the range
+        # [-32768, 32767]
+        print(ki["a"])
+        print(ki["b"])
+
+
+def test_read_wave_1():
+    file = "/ceph-fj/fangjun/open-source-2/kaldi_native_io/build/BAC009S0002W0123.wav"
+    wave = kaldi_native_io.read_wave(file)
+    print("sample_freq", wave.sample_freq)  # e.g., 1600
+    print("duration in seconds", wave.duration)
+    print("data shape", wave.data.numpy().shape)  # (num_channels, num_samples)
+    print(f"data min", wave.data.numpy().min())
+    print(f"data max", wave.data.numpy().max())
+
+
+def test_read_wave_2():
+    # from a pipe
+    file = "cat /ceph-fj/fangjun/open-source-2/kaldi_native_io/build/BAC009S0002W0123.wav |"
+    wave = kaldi_native_io.read_wave(file)
+    print("sample_freq", wave.sample_freq)
+    print("duration in seconds", wave.duration)
+    print("data shape", wave.data.numpy().shape)
+    print(f"data min", wave.data.numpy().min())
+    print(f"data max", wave.data.numpy().max())
+
+
+def main():
+    if Path(base).exists():
+        test_sequential_wave_reader()
+        test_random_access_wave_reader()
+        test_read_wave_1()
+        test_read_wave_2()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes https://github.com/csukuangfj/kaldi_native_io/issues/23 and https://github.com/lhotse-speech/lhotse/issues/659

The problem was that when the input is from a pipe, the wave info reader closes the pipe as soon as it finishes reading the data, causing the pipe writer to fail since the pipe is closed but the writer is still writing to the pipe.

The fix is to use WaveData to read all the data from the pipe, which won't close the pipe as long as the writer is still writing.