### PR TITLE
Optimize wav reading for large files,

### DIFF
--- a/kaldi_native_io/csrc/wave-reader.h
+++ b/kaldi_native_io/csrc/wave-reader.h
@@ -13,7 +13,6 @@
 #include <istream>
 #include <string>
 #include <utility>
-#include <vector>
 
 #include "kaldi_native_io/csrc/kaldi-matrix.h"
 #include "kaldi_native_io/csrc/log.h"
@@ -129,10 +128,6 @@ class WaveData {
     data_.Swap(&(other->data_));
     std::swap(samp_freq_, other->samp_freq_);
   }
-
- private:
-  /// Internal impl. of Read, reads data blockwise and merges blocks at the end.
-  static std::vector<char> ReadData(std::istream &is, const WaveInfo& header);
 
  private:
   static const uint32_t kBlockSize = 1024 * 1024;  // Use 1M bytes.

--- a/kaldi_native_io/csrc/wave-reader.h
+++ b/kaldi_native_io/csrc/wave-reader.h
@@ -13,6 +13,7 @@
 #include <istream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "kaldi_native_io/csrc/kaldi-matrix.h"
 #include "kaldi_native_io/csrc/log.h"
@@ -128,6 +129,10 @@ class WaveData {
     data_.Swap(&(other->data_));
     std::swap(samp_freq_, other->samp_freq_);
   }
+
+ private:
+  /// Internal impl. of Read, reads data blockwise and merges blocks at the end.
+  static std::vector<char> ReadData(std::istream &is, const WaveInfo& header);
 
  private:
   static const uint32_t kBlockSize = 1024 * 1024;  // Use 1M bytes.


### PR DESCRIPTION
Hello,
in the Chime challenge, we worked with 3 hour long audio files,
and I was loading them using lhotse via 'command' type Recordings.

I tried to optimize the code for loading the long wav files,
it loads the data chunk-wise into a `std::list<std::vector<char>>` as a buffer holder,
and then merges them at the end.
This avoids calling too many `std::vector::resize()` on the non-empty buffer.

I modified the tests `test_wave_info_reader.py` `test_wave_reader.py` to
use my long audio data (passing the tests). But the time measurements 
did not show any big difference.

Would you have some suggestion what to try to further optimize it ?
(I also tried using 10MB chunks from 2nd buffer on, but with no dramatic difference)
Do you have some experience with optimizing loading of wav files ?

Thank you and Best regards,
Karel Vesely, 
// i was the original author of wav loading in Kaldi 12years ago

---

Summary of the code change:
- use list of vector of buffers, instead of resizing single vector per 1MB chunks (avoid the of memcpy calls from vector::resize)
- inputs are read per 1MB chunks as before
- reading short files is optimized (swap buffer into the output vector)