### PR TITLE
[WIP] Wave read buffers as list of vectors

### DIFF
--- a/kaldi_native_io/csrc/wave-reader.cc
+++ b/kaldi_native_io/csrc/wave-reader.cc
@@ -14,6 +14,8 @@
 #include <cmath>  // for trunc()
 #include <cstring>
 #include <limits>
+#include <list>
+#include <memory>
 #include <vector>
 
 #include "kaldi_native_io/csrc/kaldi-utils.h"
@@ -275,20 +277,8 @@ void WaveData::Read(std::istream &is) {
   data_.Resize(0, 0);  // clear the data.
   samp_freq_ = header.SampFreq();
 
-  std::vector<char> buffer;
-  uint32 bytes_to_go = header.IsStreamed() ? kBlockSize : header.DataBytes();
-
-  // Once in a while header.DataBytes() will report an insane value;
-  // read the file to the end
-  while (is && bytes_to_go > 0) {
-    uint32 block_bytes = std::min(bytes_to_go, kBlockSize);
-    uint32 offset = buffer.size();
-    buffer.resize(offset + block_bytes);
-    is.read(&buffer[offset], block_bytes);
-    uint32 bytes_read = is.gcount();
-    buffer.resize(offset + bytes_read);
-    if (!header.IsStreamed()) bytes_to_go -= bytes_read;
-  }
+  const std::vector<char>& buffer = WaveData::ReadData(is, header);
+  // (the tmp object exists till end of the scope of the reference, optimization)
 
   if (is.bad()) KALDIIO_ERR << "WaveData: file read error";
 
@@ -309,6 +299,69 @@ void WaveData::Read(std::istream &is) {
       int16 k = *data_ptr++;
       if (header.ReverseBytes()) KALDIIO_SWAP2(k);
       data_(j, i) = k;
+    }
+  }
+}
+
+
+std::vector<char> WaveData::ReadData(std::istream &is, const WaveInfo& header) {
+
+  // We use list of buffers, to avoid re-allocations and memory moves when
+  // loading large files. The output vector is assembled later.
+  std::list<std::vector<char>> buffers;
+
+  // read wav data to buffers
+  {
+    int64_t bytes_to_go = header.IsStreamed() ? kBlockSize : header.DataBytes();
+
+    // Once in a while header.DataBytes() will report an insane value;
+    // read the file to the end
+    while (is && bytes_to_go > 0) {
+      // not more than kBlockSize bytes per buffer
+      uint32 block_bytes = std::min(bytes_to_go, static_cast<int64_t>(kBlockSize));
+      buffers.emplace_back(block_bytes); // add vector to back()
+      is.read(buffers.back().data(), block_bytes);
+
+      std::streamsize bytes_last_read = is.gcount(); // signed type
+      buffers.back().resize(bytes_last_read);
+
+      if (! header.IsStreamed()) bytes_to_go -= bytes_last_read;
+
+      if (is.eof()) break;
+      if (is.fail()) {
+        KALDIIO_ERR << "WaveData: file read error (stream read failed).";
+      }
+    }
+  }
+
+  // prepare the output buffer
+  {
+    std::vector<char> buffer_out;
+
+    if (buffers.size() == 0) {
+      KALDIIO_ERR << "WaveData: file read error (no buffer)";
+    }
+
+    // shortcut for small files
+    if (buffers.size() == 1) {
+      buffer_out.swap(buffers.front());
+      return buffer_out;
+    }
+
+    { // assemble the vectors to single vector
+      int32 total_size = 0;
+      for (auto& b : buffers) {
+        total_size += b.size();
+      }
+
+      // pre-allocate
+      buffer_out.reserve(total_size);
+      // concatenate buffers
+      for (auto& b : buffers) {
+        buffer_out.insert(buffer_out.end(), b.begin(), b.end());
+      }
+
+      return buffer_out;
     }
   }
 }

--- a/kaldi_native_io/csrc/wave-reader.h
+++ b/kaldi_native_io/csrc/wave-reader.h
@@ -135,7 +135,9 @@ class WaveData {
   static std::vector<char> ReadData(std::istream &is, const WaveInfo& header);
 
  private:
-  static const uint32_t kBlockSize = 1024 * 1024;  // Use 1M bytes.
+  //static const uint32_t kBlockSize = 1024 * 1024;  // Use 1M bytes.
+  //static const uint32_t kBlockSize = 100 * 1024 * 1024;  // Use 100M bytes.
+  static const uint32_t kBlockSize = 10 * 1024 * 1024;  // Use 10M bytes.
   Matrix<float> data_;
   float samp_freq_;
 };

--- a/kaldi_native_io/csrc/wave-reader.h
+++ b/kaldi_native_io/csrc/wave-reader.h
@@ -13,6 +13,7 @@
 #include <istream>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "kaldi_native_io/csrc/kaldi-matrix.h"
 #include "kaldi_native_io/csrc/log.h"
@@ -128,6 +129,10 @@ class WaveData {
     data_.Swap(&(other->data_));
     std::swap(samp_freq_, other->samp_freq_);
   }
+
+ private:
+  /// Internal impl. of Read, reads data blockwise and merges blocks at the end.
+  static std::vector<char> ReadData(std::istream &is, const WaveInfo& header);
 
  private:
   static const uint32_t kBlockSize = 1024 * 1024;  // Use 1M bytes.


### PR DESCRIPTION
Hi Fangjun @csukuangfj,
i continued the work on the idea of loading wav files to `std::list<std::vector<char>>` buffers.

The `vector::insert` was replaced by memcpy, and the sizes of set-of-buffers 
now copy the series of powers of two, as : 10, 20, 40, 80, ... MBs.

The speedup on 600MB wav file was 5% (10s -> 9.5s with 6 reads).

By setting the kBlockSize to 1GB (load everything to 1 vector, and `swap()` 
it to the output vector, the speedup was ~15% (10s -> 8.55s).

This seems to be the upper bound for the possibility of optimization.
And similar effect would be achieved by filling the final `Matrix<float>` 
directly from the `std::list<std::vector<char>>` set-of-buffers 
(there is one less memory copy).

Would you be interested in having this optimization in your repo ?

The current version in `master` is simple. And with the optimization 
it would be 15% faster on very long wave files (~3 hours). The loading 
speed of "normal" files should stay about the same...

I am asking, before rewriting the code again.

Best regards,
Karel.